### PR TITLE
feat: respect users color scheme preference

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -129,6 +129,10 @@ const config = {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
       },
+      colorMode: {
+        disableSwitch: false,
+        respectPrefersColorScheme: true,
+      },
     }),
 };
 


### PR DESCRIPTION
When the system preference is set to dark mode, Getdeck docs will now be set to dark mode by default.