### PR TITLE
Add kind docs and fix typos

### DIFF
--- a/docs/deck/deck.md
+++ b/docs/deck/deck.md
@@ -9,11 +9,11 @@ Deck is a new concept coming with **Getdeck**. A simple attempt to explain it wo
 
 To stay with the nautical metaphor around Kubernetes: You may work on a large ship and that very ship is 
 divided into multiple decks. You can work one day on deck A - and on deck B the other day. However, since both decks 
-are on the same ship they share a common ground. The Getdeck team decided to call installable units a deck, 
-because even the smallest ships has at least one deck. Decks on a ship usually serve different purposes or offer 
-certain capabilities and so are decks in Getdeck.
+are on the same ship, they share a common ground. The Getdeck team decided to call installable units a deck, 
+because even the smallest ships have at least one deck. Decks on a ship usually serve different purposes or offer 
+certain capabilities and so do the decks in Getdeck.
 
-Decks do share common components which might end up as a production platform playing together. However, since it is not 
+Decks do share common components, which might end up as a production platform playing together. However, since it is not 
 always feasible to run the entire production infrastructure on your Pentium 3 notebook, decks form a certain excerpt for 
 you to work on. Just enough to get your work done in the required context. If you need another deck, ask your operators 
 to create it upon your requirements or go on and define it yourself.
@@ -23,4 +23,4 @@ Find deck examples at the [Deckfile specification](/docs/deckfile/specs) page.
 Providing a _Deckfile_ is crucial for working with Getdeck. It's like a `docker-compose.yaml` for Kubernetes-based development
 environments. However, it is more difficult to compose a Kubernetes workload than a docker-compose file, as it requires
 the knowledge of a Kubernetes practitioner. Please read on how to write a Deckfile to specify a Kubernetes-based development
-which is close to your production system by using the workload descriptors you potentially already use.
+that is close to your production system by using the workload descriptors you potentially already use.

--- a/docs/deck/for-devops/intro.md
+++ b/docs/deck/for-devops/intro.md
@@ -2,7 +2,7 @@
 sidebar_position: 1
 ---
 # Introduction for DevOps or Kubernetes Operators
-You are probably already mastering Kubernetes and all its strings attached. In order to lower the pressure on
+You are probably already mastering Kubernetes and all its strings attached.To lower the pressure on
 the Kubernetes experts within development teams, Getdeck promotes the approach to _fail fast during development_.
 Things that do not work as expected in a local Kubernetes-based development environments won't probably work on 
 _integration_ or _production_, too. However, developers main task is writing code, not dealing with complex operations (or

--- a/docs/deck/for-devs/cli-reference.md
+++ b/docs/deck/for-devs/cli-reference.md
@@ -19,7 +19,7 @@ Global flags are:
 
 
 # Actions
-The CLI allows to run the following available actions.
+The CLI allows running the following available actions.
 
 ## `deck get`
 Create (or reuse) a Kubernetes cluster and install the selected deck to it. The `Deckfile` parameter 

--- a/docs/deck/for-devs/intro.md
+++ b/docs/deck/for-devs/intro.md
@@ -2,8 +2,8 @@
 sidebar_position: 1
 ---
 # Introduction for Developers
-If you want to follow [The Twelve-Factor App](https://12factor.net/) methodology for building software you also want to
-adhere factor [X. Dev/prod parity](https://12factor.net/dev-prod-parity). If you are running `docker-compose`, `vagrant`
+If you want to follow [The Twelve-Factor App](https://12factor.net/) methodology for building software, you also want to
+adhere to factor [X. Dev/prod parity](https://12factor.net/dev-prod-parity). If you are running `docker-compose`, `vagrant`
 or local _virtualenv_ (of any kind) without using containers, you are not really following this approach 
 (or at least this factor). You need to work with Kubernetes during development time, too.  
 In order to get a close-to-production development environment, kindly ask your DevOps or operations staff to provide you 

--- a/docs/deck/for-devs/working-with-deck.md
+++ b/docs/deck/for-devs/working-with-deck.md
@@ -3,21 +3,21 @@ sidebar_position: 2
 ---
 # Working with Decks and the CLI
 A [Deckfile](/docs/deckfile/specs) can be understood similar to what a `docker-compose` file is doing for a developer.
-It creates a development infrastructure, usually coming with multiple services, e.g. databases, full-text search indexes
+It creates a development infrastructure, usually with multiple services, e.g. databases, full-text search indexes
 and applications. However, in opposite to a docker-compose file, a Deckfile creates that infrastructure based on a real
 Kubernetes cluster (not just `docker run ...` with some on-top convenience).  
 
 Ideally, the Deckfile for a developer's setup draws the Kubernetes workloads from production(-close) environments. That
 allows development teams to share the configuration in which a container is finally operated.  
-Getdeck provides a CLI `deck` which comes with most of the popular tools from the Kubernetes ecosystem without having them
+Getdeck provides a CLI `deck`, which comes with most of the popular tools from the Kubernetes ecosystem without having them
 locally managed. This includes `Helm` (with plugins), `kustomize` and others. Getdeck allows provisioning Kubernetes
-clusters without having developers to know all the ins and outs of these tools. Hence, the process of spinning up development
+clusters without requiring developers to know all the ins and outs of these tools. Hence, the process of spinning up development
 setups becomes a breeze.
 
 ## Setup a local development infrastructure
-Of course, there a countless numbers of development setups, requirements and moving parts in production. However, Getdeck
-is designed to be as versatile as possible to different use-case scenarios.
-Let's assume you want to provision a common Kubernetes-based tech stack on your machine. Either you find what you need
+Of course, there are countless numbers of development setups, requirements and moving parts in production. However, Getdeck
+is designed to be as versatile as possible for different use-case scenarios.
+Let's assume you want to provide a common Kubernetes-based tech stack on your machine. Either you find what you need
 in Getdeck's [Wharf](/docs/deckfile/wharf), or you have to write your own Deckfile.  
 **Important:** If you find a popular stack missing in    Wharf, please consider adding it with a 
 [_Pull Request_ on Github](https://github.com/Getdeck/wharf).  
@@ -34,16 +34,16 @@ There are a couple of steps automated with the `get`-operation:
 4. Pull the Kubernetes manifest sources from all specified locations using the identity of the user  
 5. Preprocess manifest sources, for example generate _Helm charts_ with the configuration from the Deckfile  
 6. Apply all workload manifests to the Kubernetes cluster  
-7. Print useful information about the setup and how to get started working with it  
+7. Print helpful information about the setup and how to get started working with it  
 8. Optionally: wait for all Pods to become ready  
 
 This process is supervised by `deck` to handle common errors or revert everything in case of an unfixable error. Upon
 a technical issue the cluster is removed immediately.  
-In case of persistent errors the _debug_ flag (`deck -d get ...`) can help to find out what is causing the problem.
+In case of persistent errors the _debug_ flag (`deck -d get ...`) can help to determine what is causing the problem.
 
 This operation can be run as often as needed. Running it later on will cause your development setup to stay up-to-date
 with the Deckfile in case it is pulled from a remote location.  
-If you need more than one Deck (and the Deckfiles in question also specifies multiple Decks), you can run `deck get --name ...` for each
+If you need more than one Deck (and the Deckfile in question also specifies multiple Decks), you can run `deck get --name ...` for each
 required Deck from the file. This will still create only one cluster (effectively sharing it between Decks) and install 
 multiple Decks to it. This can be useful for multiple development teams which are developing different services communicating with
 each other.
@@ -51,8 +51,8 @@ each other.
 This operation is similar to `docker-compose up -d`
 
 ## Halt the development infrastructure
-The `stop`-operation allows to pause the current Kubernetes development cluster while keeping the state in place. Depending
-on the Kubernetes provider this will shut down the cluster effectively saving resources.  
+The `stop`-operation allows pausing the current Kubernetes development cluster while keeping the state in place. Depending
+on the Kubernetes provider, this will shut down the cluster effectively saving resources.  
 If a cluster is stopped, running another `deck get ...` on a Deckfile will bring this existing cluster back to life.  
 
 This operation is similar to `docker-compose stop`

--- a/docs/deck/getting-started.md
+++ b/docs/deck/getting-started.md
@@ -9,7 +9,7 @@ We provide a sophisticated demo project you can deploy locally using `Getdeck`:
 deck get https://github.com/gefyrahq/gefyra-demos.git
 ```
 
-This might take a few minutes. When its done, open your browser at
+This might take a few minutes. When it's done, open your browser at
 [http://dashboard.127.0.0.1.nip.io:8080/#/workloads?namespace=oauth2-demo](http://dashboard.127.0.0.1.nip.io:8080/#/workloads?namespace=oauth2-demo).
 You should see a kubernetes dashboard with some information about the namespace:
 

--- a/docs/deck/installation.md
+++ b/docs/deck/installation.md
@@ -20,11 +20,11 @@ curl -sSL https://raw.githubusercontent.com/getdeck/getdeck/main/install.sh | sh
 </TabItem>
 <TabItem value="windows" label="Windows">
 You can download the latest release from <a href="https://github.com/Getdeck/getdeck/releases/">https://github.com/Getdeck/getdeck/releases/</a> and extract the binary on your local machine.
-Chocolatey will be available soon. If you can support this project with packaging and distributing for Windows please get in touch!
+Chocolatey will be available soon. If you can support this project with packaging and distribution for Windows, please get in touch!
 </TabItem>
 <TabItem value="linux" label="Linux" default>
 
-We provide a simple installation script, which will take care for everything:
+We provide a simple installation script, which will take care of everything:
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/getdeck/getdeck/main/install.sh | sh -

--- a/docs/deck/intro.md
+++ b/docs/deck/intro.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 ## Introduction
 
-**Getdeck** is a command line application (`deck`) and file specification (`Deckfile`) around the concept of a 
+**Getdeck** is a command-line application (`deck`) and file specification (`Deckfile`) around the concept of a 
 Kubernetes _Deck_. If you want to know more about the concept itself, head over 
 to [the documentation of the concept](/docs/deck) or the [Deckfile specification](/docs/deckfile/specs).
 Getdeck handles the workflow of providing parts of your existing Kubernetes infrastructure to Developers or
@@ -14,10 +14,10 @@ Testers without having them to be Kubernetes experts, too. Think of Getdeck as t
 existing Kubernetes workloads.
 
 > If you already have members in your team putting a lot of effort in writing secure, compliant and off-the-shelf
-> Kubernetes workloads, why don't you use (at leasts parts of it) these for development, too?
+> Kubernetes workloads, why don't you use (at least parts of it) these for development, too?
 
 ### Are you a developer?
-You understand your main task in writing code? - follow along [the developer specific introduction](for-devs/intro).
+You understand your main task in writing code? - follow along [the developer-specific introduction](for-devs/intro).
 
 
 ### Are you a DevOps?
@@ -28,7 +28,7 @@ follow along [the DevOps specific introduction](for-devops/intro).
 
 ## Features
 
-The following features are currently scope of Getdeck:
+The following features are currently the scope of Getdeck:
 * Roll out different Kubernetes-cluster on local development machines: 
   * [`k3d`](https://k3d.io)
   * [`kind`](https://kind.sigs.k8s.io/)


### PR DESCRIPTION
Adding `kind` as an available provider with an example configuration.
Fixing typos or wording problems in different files.